### PR TITLE
Default configuration variable without setting up env that works out of the box

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -6,16 +6,16 @@ class BaseConfig:
     # fetch database environment from .env
     # TODO: change the credentials later
     DB_PROVIDER = os.environ.get('DB_PROVIDER', 'mysql+pymysql')
-    DB_DATABASE = os.environ.get('DB_DATABASE', 'mysql')
-    DB_USER = os.environ.get('DB_USER', 'pawan')
-    DB_PASSWORD = os.environ.get('DB_PASSWORD', 'password')
-    DB_HOST = os.environ.get('DB_HOST', 'mysql')
+    DB_DATABASE = os.environ.get('DB_DATABASE', 'ms-api')
+    DB_USER = os.environ.get('DB_USER', 'root')
+    DB_PASSWORD = os.environ.get('DB_PASSWORD', 'root')
+    DB_HOST = os.environ.get('DB_HOST', 'localhost')
     DB_PORT = os.environ.get('DB_PORT', '3306')
 
     SQLALCHEMY_DATABASE_URL = f"{DB_PROVIDER}://{DB_USER}:{DB_PASSWORD}@{DB_HOST}:{DB_PORT}/{DB_DATABASE}"
     DATABASE_CONNECT_DICT: dict = {}
 
-    POST_API_HOST = os.environ.get('POST_API_HOST', 'http://localhost:8080/api')
+    POST_API_HOST = os.environ.get('POST_API_HOST', '') #Example http://<your_host>/api
 
 
 class DevelopmentConfig(BaseConfig):


### PR DESCRIPTION
Since .env.example file is not loaded at default so we can relay on default environment variables out of the box.